### PR TITLE
Add result details in response parameters, and improve custom parameters

### DIFF
--- a/opp/facade.py
+++ b/opp/facade.py
@@ -527,7 +527,7 @@ class ResponseParameters(object):
     def __init__(self, id=None, payment_type=None, payment_brand=None, amount=None, currency=None, descriptor=None,
                  result=None, card_account=None, virtual_account=None, bank_account=None, customer=None,
                  billing_address=None, shipping_address=None, cart=None, merchant=None, redirect=None,
-                 timestamp=None, build_number=None, ndc=None):
+                 timestamp=None, build_number=None, ndc=None, result_details=None):
         self.id = id
         self.payment_type = payment_type
         self.payment_brand = payment_brand
@@ -547,6 +547,7 @@ class ResponseParameters(object):
         self.timestamp = timestamp
         self.build_number = build_number
         self.ndc = ndc
+        self.result_details = result_details
 
     @staticmethod
     def from_params(params):
@@ -575,6 +576,7 @@ class ResponseParameters(object):
             timestamp = params.get('timestamp')
             build_number = params.get('buildNumber')
             ndc = params.get('ndc')
+            result_details = params.get('resultDetails')
             response_params = ResponseParameters(id=id, payment_type=payment_type, payment_brand=payment_brand,
                                                  amount=amount, currency=currency, descriptor=descriptor,
                                                  result=result, card_account=card_account,
@@ -582,7 +584,7 @@ class ResponseParameters(object):
                                                  bank_account=bank_account, customer=customer,
                                                  billing_address=billing_address, shipping_address=shipping_address,
                                                  cart=cart, merchant=merchant, redirect=redirect, timestamp=timestamp,
-                                                 build_number=build_number, ndc=ndc)
+                                                 build_number=build_number, ndc=ndc, result_details=result_details)
 
             return response_params
 

--- a/opp/facade.py
+++ b/opp/facade.py
@@ -427,19 +427,23 @@ class ThreeDSecure(object):
 
 
 class CustomParameters(object):
-    def __init__(self, **kwargs):
+    def __init__(self, use_shopper_prefix=True, **kwargs):
         """
+        :param use_shopper_prefix: whether "SHOPPER_" prefix should be used or not for parameters names
         :param kwargs:
         :rtype : object
         :param name:
         """
+        self.use_shopper_prefix = use_shopper_prefix
         for key, value in six.iteritems(kwargs):
             self.__dict__.update({key: value})
 
     def to_params(self):
         params = {}
+        prefix = 'SHOPPER_' if self.use_shopper_prefix else ''
+        self.__dict__.pop('use_shopper_prefix')
         for key, value in six.iteritems(self.__dict__):
-            params.update({"customParameters[SHOPPER_{0}]".format(key): value})
+            params.update({"customParameters[{prefix}{key}]".format(prefix=prefix, key=key): value})
         return params
 
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import setup
 
 setup(
     name='opp',
-    version='1.0.0',
+    version='1.1.0',
     description='Python wrapper for OPP',
     author='PAY.ON',
     author_email='opp@payon.com',
@@ -30,5 +30,5 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
     install_requires=install_requires,
-    download_url='https://github.com/OpenPaymentPlatform/python/tarball/1.0.0'
+    download_url='https://github.com/OpenPaymentPlatform/python/tarball/1.1.0'
 )

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import setup
 
 setup(
     name='opp',
-    version='1.1.0',
+    version='1.2.0',
     description='Python wrapper for OPP',
     author='PAY.ON',
     author_email='opp@payon.com',
@@ -30,5 +30,5 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
     install_requires=install_requires,
-    download_url='https://github.com/OpenPaymentPlatform/python/tarball/1.1.0'
+    download_url='https://github.com/OpenPaymentPlatform/python/tarball/1.2.0'
 )

--- a/tests/facade/test_from_params.py
+++ b/tests/facade/test_from_params.py
@@ -336,7 +336,13 @@ class TestFromParams(unittest.TestCase):
                                },
                                "buildNumber": "20150707-105209.r185912.opp-tags-20150709_lr",
                                "timestamp": "2015-07-10 04:28:03+0000",
-                               "ndc": "8a8294174b7ecb28014b9699220015ca_8a102b3e46974c83bbeb0bfc62a9518e"
+                               "ndc": "8a8294174b7ecb28014b9699220015ca_8a102b3e46974c83bbeb0bfc62a9518e",
+                               "resultDetails": {
+                                   "ConnectorTxID1": "8a8393c259876e841989ab6f4da1408d",
+                                   "ConnectorTxID2": "614486",
+                                   "ConnectorTxID3": "827428|||74301731986",
+                                   "clearingInstituteName": "Some Institute",
+                               }
                                }
         response = opp.facade.ResponseParameters.from_params(response_parameters)
         self.assertEqual(response.id, "8a8294494e735cfa014e763863a80add")
@@ -407,3 +413,7 @@ class TestFromParams(unittest.TestCase):
         self.assertEqual(response.build_number, "20150707-105209.r185912.opp-tags-20150709_lr")
         self.assertEqual(response.timestamp, "2015-07-10 04:28:03+0000")
         self.assertEqual(response.ndc, "8a8294174b7ecb28014b9699220015ca_8a102b3e46974c83bbeb0bfc62a9518e")
+        self.assertEqual(response.result_details["ConnectorTxID1"], "8a8393c259876e841989ab6f4da1408d")
+        self.assertEqual(response.result_details["ConnectorTxID2"], "614486")
+        self.assertEqual(response.result_details["ConnectorTxID3"], "827428|||74301731986")
+        self.assertEqual(response.result_details["clearingInstituteName"], "Some Institute")

--- a/tests/facade/test_to_params.py
+++ b/tests/facade/test_to_params.py
@@ -161,6 +161,14 @@ class TestToParams(unittest.TestCase):
         result_parameters = opp.facade.CustomParameters(number_of_installments='3', trial_period_days='10').to_params()
         self.assertEqual(expected_parameters, result_parameters)
 
+    def test_custom_parameters_to_params_without_shopper_prefix(self):
+        expected_parameters = {"customParameters[number_of_installments]": "3",
+                               "customParameters[trial_period_days]": "10"
+                               }
+        result_parameters = opp.facade.CustomParameters(number_of_installments='3', trial_period_days='10',
+                                                        use_shopper_prefix=False).to_params()
+        self.assertEqual(expected_parameters, result_parameters)
+
     def test_asynchronous_payments_to_params(self):
         expected_parameters = {"shopperResultUrl": "http://shopperurl.com",
                                "notificationUrl": "http://notificationurl.com"


### PR DESCRIPTION
Hi,

Please find in this PR two changes:
- Add result details in response parameters
- Payment custom parameters: option to avoid using the SHOPPER_ prefix

Feel free to upload the pypi package. ;)